### PR TITLE
Fix markdown header levels, move license to the end

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,7 @@
-## Create a virtual assistant for iOS using Watson Assistant
-
 [![](https://img.shields.io/badge/bluemix-powered-blue.svg)](https://bluemix.net)
 [![Platform](https://img.shields.io/badge/platform-ios_swift-lightgrey.svg?style=flat)](https://developer.apple.com/swift/)
 
-### Table of Contents
-
-* [Summary](#summary)
-* [Flow](#flow)
-* [Components](#included-components)
-* [Technologies](#featured-technologies)
-* [Requirements](#requirements)
-* [Steps](#steps)
-* [Sample Output](#sample-output)
-* [License](#license)
-* [Links](#links)
-* [Learn more](#learn-more)
-
-### Summary
+# Create a virtual assistant for iOS using Watson Assistant
 
 This IBM Cloud Starter Kit will showcase the Watson Assistant service on iOS. We'll walk through setting up Xcode, installing dependencies, and running the application.
 
@@ -135,13 +120,7 @@ You can now run the application on a simulator or physical device. Try a few que
 
 ![](https://raw.githubusercontent.com/IBM/pattern-utils/master/virtual-assistant-for-ios/output.gif)
 
-# License
-
-This code pattern is licensed under the Apache Software License, Version 2.  Separate third party code objects invoked within this code pattern are licensed by their respective providers pursuant to their own separate licenses. Contributions are subject to the [Developer Certificate of Origin, Version 1.1 (DCO)](https://developercertificate.org/) and the [Apache Software License, Version 2](http://www.apache.org/licenses/LICENSE-2.0.txt).
-
-[Apache Software License (ASL) FAQ](http://www.apache.org/foundation/license-faq.html#WhatDoesItMEAN)
-
-# Links
+## Links
 
 * [Swift Programming Guide](https://console.bluemix.net/docs/swift/index.html#set_up): Tutorial on Swift app development.
 * [Add a Service to Your App](https://console.bluemix.net/docs/apps/reqnsi.html#add_service): Learn how to add a resource to your cloud-native app.
@@ -151,3 +130,9 @@ This code pattern is licensed under the Apache Software License, Version 2.  Sep
 * [Other Starter Kits](https://console.bluemix.net/developer/appservice/starter-kits/): Enjoyed this Starter Kit? Check out our other Starter Kits.
 * [Architecture Center](https://www.ibm.com/cloud/garage/architectures): Explore Architectures that provide flexible infrastructure solutions.
 * [IBM Watson Assistant Docs](https://console.bluemix.net/docs/services/conversation/getting-started.html#gettingstarted)
+
+## License
+
+This code pattern is licensed under the Apache Software License, Version 2.  Separate third party code objects invoked within this code pattern are licensed by their respective providers pursuant to their own separate licenses. Contributions are subject to the [Developer Certificate of Origin, Version 1.1 (DCO)](https://developercertificate.org/) and the [Apache Software License, Version 2](http://www.apache.org/licenses/LICENSE-2.0.txt).
+
+[Apache Software License (ASL) FAQ](http://www.apache.org/foundation/license-faq.html#WhatDoesItMEAN)


### PR DESCRIPTION
* Move badges to be above the title
* Move the "summary" text to the beginning instead of being obtusely labeled as such
* Use the correct header level for the title
* Use the correct header levels for top-level sections
* Move the license section to the end
* Drop the table of contents (because they tend not to be maintained)